### PR TITLE
Silence @Sendable warnings

### DIFF
--- a/Sources/Capsule/NotificationCenter.swift
+++ b/Sources/Capsule/NotificationCenter.swift
@@ -27,12 +27,17 @@ public protocol NotificationCenterProtocol {
                      selector aSelector: Selector,
                      name aName: NSNotification.Name?,
                      object anObject: Any?)
-    
+#if swift(>=5.5)
+    func addObserver(forName name: NSNotification.Name?,
+                     object obj: Any?,
+                     queue: OperationQueue?,
+                     using block: @escaping @Sendable (Notification) -> Void) -> NSObjectProtocol
+#else
     func addObserver(forName name: NSNotification.Name?,
                      object obj: Any?,
                      queue: OperationQueue?,
                      using block: @escaping (Notification) -> Void) -> NSObjectProtocol
-    
+#endif
     func removeObserver(_ observer: Any)
     func removeObserver(_ observer: Any,
                         name aName: NSNotification.Name?,

--- a/Sources/Capsule/URLSession.swift
+++ b/Sources/Capsule/URLSession.swift
@@ -25,7 +25,11 @@ import Foundation
 public protocol URLSessionProtocol {
     init(configuration: URLSessionConfiguration)
 
+#if swift(>=5.5)
+    func dataTask(with url: URL, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+#else
     func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+#endif
 }
 
 extension URLSession: URLSessionProtocol { }


### PR DESCRIPTION
Add:

```
#if swift(>=5.5)
```

checks to a couple of protocols to handle the new `@Sendable` "keyword." 